### PR TITLE
feat(app): fetch customization data from remote for quickAccess and techRadar

### DIFF
--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -1,0 +1,10 @@
+export interface Config {
+  /** Configurations for the backstage(janus) instance */
+  developerHub?: {
+    /**
+     * The url of json data for customization.
+     * @visibility frontend
+     */
+    proxyPath?: string;
+  };
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -96,6 +96,8 @@
     ]
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/packages/app/src/api/index.ts
+++ b/packages/app/src/api/index.ts
@@ -1,0 +1,69 @@
+import {
+  ConfigApi,
+  createApiRef,
+  DiscoveryApi,
+} from '@backstage/core-plugin-api';
+import { TechRadarLoaderResponse } from '@backstage/plugin-tech-radar';
+import { QuickAccessLinks } from '../types/types';
+
+const DEFAULT_PROXY_PATH = '/developer-hub';
+
+export interface JanusBackstageCustomizeApi {
+  getHomeDataJson(): Promise<QuickAccessLinks[]>;
+  getTechRadarDataJson(): Promise<TechRadarLoaderResponse>;
+}
+
+export const janusBackstageCustomizeApiRef =
+  createApiRef<JanusBackstageCustomizeApi>({
+    id: 'app.developer-hub.service',
+  });
+
+export type Options = {
+  discoveryApi: DiscoveryApi;
+  configApi: ConfigApi;
+};
+
+export class JanusBackstageCustomizeApiClient
+  implements JanusBackstageCustomizeApi
+{
+  // @ts-ignore
+  private readonly discoveryApi: DiscoveryApi;
+
+  private readonly configApi: ConfigApi;
+
+  constructor(options: Options) {
+    this.discoveryApi = options.discoveryApi;
+    this.configApi = options.configApi;
+  }
+
+  private async getBaseUrl() {
+    const proxyPath =
+      this.configApi.getOptionalString('developerHub.proxyPath') ||
+      DEFAULT_PROXY_PATH;
+    return `${await this.discoveryApi.getBaseUrl('proxy')}${proxyPath}`;
+  }
+
+  private async fetcher(url: string) {
+    const response = await fetch(url, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `failed to fetch data, status ${response.status}: ${response.statusText}`,
+      );
+    }
+    return await response.json();
+  }
+
+  async getHomeDataJson() {
+    const proxyUrl = await this.getBaseUrl();
+    const data = await this.fetcher(`${proxyUrl}`);
+    return data;
+  }
+
+  async getTechRadarDataJson() {
+    const proxyUrl = await this.getBaseUrl();
+    const data = await this.fetcher(`${proxyUrl}/tech-radar`);
+    return data;
+  }
+}

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -3,6 +3,7 @@ import {
   analyticsApiRef,
   configApiRef,
   createApiFactory,
+  discoveryApiRef,
   identityApiRef,
 } from '@backstage/core-plugin-api';
 import {
@@ -13,6 +14,10 @@ import {
 import { techRadarApiRef } from '@backstage/plugin-tech-radar';
 import { SegmentAnalytics } from '@janus-idp/backstage-plugin-analytics-provider-segment';
 import { CustomTechRadar } from './lib/CustomTechRadar';
+import {
+  JanusBackstageCustomizeApiClient,
+  janusBackstageCustomizeApiRef,
+} from './api';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -21,11 +26,27 @@ export const apis: AnyApiFactory[] = [
     factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
   }),
   ScmAuth.createDefaultApiFactory(),
-  createApiFactory(techRadarApiRef, new CustomTechRadar()),
   createApiFactory({
     api: analyticsApiRef,
     deps: { configApi: configApiRef, identityApi: identityApiRef },
     factory: ({ configApi, identityApi }) =>
       SegmentAnalytics.fromConfig(configApi, identityApi),
+  }),
+  createApiFactory({
+    api: janusBackstageCustomizeApiRef,
+    deps: {
+      discoveryApi: discoveryApiRef,
+      configApi: configApiRef,
+    },
+    factory: ({ discoveryApi, configApi }) =>
+      new JanusBackstageCustomizeApiClient({ discoveryApi, configApi }),
+  }),
+  createApiFactory({
+    api: techRadarApiRef,
+    deps: {
+      janusBackstageCustomizeApi: janusBackstageCustomizeApiRef,
+    },
+    factory: ({ janusBackstageCustomizeApi }) =>
+      new CustomTechRadar({ janusBackstageCustomizeApi }),
   }),
 ];

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -9,7 +9,6 @@ import {
   ComponentAccordion,
   HomePageStarredEntities,
   HomePageToolkit,
-  type Tool,
 } from '@backstage/plugin-home';
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import { SearchContextProvider } from '@backstage/plugin-search-react';
@@ -17,9 +16,9 @@ import { css } from '@emotion/css';
 import MuiAlert from '@mui/lab/Alert';
 import { Box, CircularProgress, Grid } from '@mui/material';
 import React from 'react';
-import useSWR from 'swr';
 import { makeStyles } from 'tss-react/mui';
-import { ErrorReport, fetcher } from '../../common';
+import { ErrorReport } from '../../common';
+import { useQuickAccess } from '../../hooks/useQuickAccess';
 
 const useStyles = makeStyles()(theme => ({
   img: {
@@ -35,18 +34,13 @@ const useStyles = makeStyles()(theme => ({
   },
 }));
 
-type QuickAccessLinks = {
-  title: string;
-  isExpanded?: boolean;
-  links: (Tool & { iconUrl: string })[];
-};
-
 const QuickAccess = () => {
   const { classes } = useStyles();
-  const { data, error, isLoading } = useSWR(
-    '/homepage/data.json',
-    fetcher<QuickAccessLinks>,
-  );
+  const { data, error, isLoading } = useQuickAccess();
+
+  if (isLoading) {
+    return <CircularProgress />;
+  }
 
   if (!data) {
     return (
@@ -54,14 +48,10 @@ const QuickAccess = () => {
     );
   }
 
-  if (error) {
+  if (!isLoading && !data && error) {
     return (
       <ErrorReport title="Could not fetch data." errorText={error.toString()} />
     );
-  }
-
-  if (isLoading) {
-    return <CircularProgress />;
   }
 
   return (

--- a/packages/app/src/hooks/useQuickAccess.ts
+++ b/packages/app/src/hooks/useQuickAccess.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { janusBackstageCustomizeApiRef } from '../api';
+import useAsync from 'react-use/lib/useAsync';
+import { QuickAccessLinks } from '../types/types';
+
+export const useQuickAccess = () => {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [data, setData] = useState<QuickAccessLinks[]>();
+  const [error, setError] = useState<any>();
+  const client = useApi(janusBackstageCustomizeApiRef);
+  const {
+    value,
+    error: apiError,
+    loading,
+  } = useAsync(() => client.getHomeDataJson());
+
+  const fetchData = useCallback(async () => {
+    const res = await fetch('/homepage/data.json');
+    const qsData = await res.json();
+    setData(qsData);
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (apiError) {
+      setError(apiError);
+      fetchData().catch(err => {
+        setError(err);
+        setIsLoading(false);
+      });
+    } else if (!loading && value) {
+      setData(value);
+      setIsLoading(false);
+    }
+  }, [apiError, fetchData, loading, setData, value]);
+
+  return { data, error, isLoading };
+};

--- a/packages/app/src/lib/CustomTechRadar.ts
+++ b/packages/app/src/lib/CustomTechRadar.ts
@@ -2,12 +2,23 @@ import {
   TechRadarApi,
   type TechRadarLoaderResponse,
 } from '@backstage/plugin-tech-radar';
+import { JanusBackstageCustomizeApi } from '../api';
 
 export class CustomTechRadar implements TechRadarApi {
+  private readonly janusBackstageCustomizeApi: JanusBackstageCustomizeApi;
+  constructor(options: {
+    janusBackstageCustomizeApi: JanusBackstageCustomizeApi;
+  }) {
+    this.janusBackstageCustomizeApi = options.janusBackstageCustomizeApi;
+  }
   async load(id: string | undefined): Promise<TechRadarLoaderResponse> {
-    const data = (await fetch(`/tech-radar/data-${id}.json`).then(res =>
-      res.json(),
-    )) as TechRadarLoaderResponse;
+    let data;
+    try {
+      data = await this.janusBackstageCustomizeApi.getTechRadarDataJson();
+    } catch (e) {
+      const res = await fetch(`/tech-radar/data-${id}.json`);
+      data = (await res.json()) as TechRadarLoaderResponse;
+    }
 
     return {
       ...data,

--- a/packages/app/src/types/types.ts
+++ b/packages/app/src/types/types.ts
@@ -1,0 +1,7 @@
+import { Tool } from '@backstage/plugin-home';
+
+export type QuickAccessLinks = {
+  title: string;
+  isExpanded?: boolean;
+  links: (Tool & { iconUrl: string })[];
+};


### PR DESCRIPTION
## Description

This is manual cherry-pick for https://github.com/janus-idp/backstage-showcase/pull/351

1. data powering the home page for quick access link is in code itself (https://github.com/janus-idp/backstage-showcase/blob/main/packages/app/public/homepage/data.json) which ideally should be configurable.
2. data powering the techRadar plugin is in code itself (https://github.com/janus-idp/backstage-showcase/blob/main/packages/app/public/tech-radar/data-default.json) which ideally should be configurable.


As part of this PR made the data for the home page configurable so that can be passed in `app-config.yaml `as a proxy. API url will return the data in JSON in the expected format/signature and fallback to the local data if api call fails or not configured.

For Home page(Quick Access links, the base URL at target should serve and for tech radar then svc URL should be `/tech-radar`

- Add below to app-config.yaml

```
proxy:
  # customize backstage(janus) instance
  '/developer-hub':
    target: ${HOMEPAGE_DATA_URL}
    headers:
       <header_key>: <header_value>
    changeOrigin: true
    secure: true
```

- Make sure the API URL passed in the target above returns the JSON in response in the expected format as here https://github.com/janus-idp/backstage-showcase/blob/main/packages/app/public/homepage/data.json


## Which issue(s) does this PR fix

- Fixes: https://github.com/janus-idp/backstage-showcase/issues/356

## How to test changes / Special notes to the reviewer

- Add below to app-config.yaml

```
proxy:
  # customize backstage(janus) instance
  '/developer-hub':
    target: ${HOMEPAGE_DATA_URL}
    headers:
       <header_key>: <header_value>
    changeOrigin: true
    secure: true
```

- Make sure the API URL passed in the target above returns the JSON in response in the expected format as here https://github.com/janus-idp/backstage-showcase/blob/main/packages/app/public/homepage/data.json

- If you want to test with actual service then can use https://github.com/invincibleJai/test-showcase-app
